### PR TITLE
HttpClient を分離したい

### DIFF
--- a/simple-chat/Assets/Script/SimpleChat/ChatApplication.cs
+++ b/simple-chat/Assets/Script/SimpleChat/ChatApplication.cs
@@ -1,51 +1,50 @@
 ﻿using System.Threading;
 using UnityEngine;
 using UnityEngine.UI;
-using WebSocketSharp;
 
 namespace SimpleChat
 {
     public class ChatApplication : MonoBehaviour
     {
-        private InputFieldView inputFieldView;
         [SerializeField]
         private InputField inputField;
 
-        private WebSocket ws;
+        private InputFieldView inputFieldView;
+
+        private SynchronizationContext context;
+
+        private HttpClient httpClient;
 
         void Awake()
         {
-            // メインスレッドを表す context
-            var context = SynchronizationContext.Current;
+
             inputFieldView = inputField.GetComponent<InputFieldView>();
 
-            // TODO: プロトコルを wss にしたい see: https://github.com/sta/websocket-sharp
-            ws = new WebSocket("ws://localhost:3000/");
-            ws.OnOpen += (sender, e) => { Debug.Log("WebSocket Open"); };
-            ws.OnMessage += (sender, e) =>
-            {
-                // メインスレッドに処理を戻す
-                context.Post(__ => {
-                    string message = System.Text.Encoding.UTF8.GetString(e.RawData);
-                    inputFieldView.ReceiveMessage(message);
-                }, null);
-            };
-            ws.OnError += (sender, e) => { Debug.Log("WebSocket Error Message: " + e.Message); };
-            ws.OnClose += (sender, e) => { Debug.Log("WebSocket Close"); };
+            // メインスレッドを表す context
+            context = SynchronizationContext.Current;
 
-            ws.Connect();
-            inputField.onEndEdit.AddListener(delegate { SendMessage(inputField); });
+            httpClient = new HttpClient();
+            httpClient.ReceiveMessageCallback = ReceiveMessageCallback;
+            httpClient.TryConnect();
+
+            inputFieldView.InputMessageCallback = SendToMessage;
         }
 
-        private void SendMessage(InputField input) {
-            byte[] data = System.Text.Encoding.UTF8.GetBytes(input.textComponent.text); 
-            ws.Send(data); 
+        private void SendToMessage(string message) {
+            httpClient.Send(message);
+        }
+
+        public void ReceiveMessageCallback(string message)
+        {
+             // メインスレッドに処理を戻す
+            context.Post(__ => {
+                inputFieldView.ReceiveMessage(message);
+            }, null);
         }
 
         public void Destroy()
         {
-            ws.Close();
-            ws = null;
+            httpClient.Destroy();
         }
     }
 }

--- a/simple-chat/Assets/Script/SimpleChat/HttpClient.cs
+++ b/simple-chat/Assets/Script/SimpleChat/HttpClient.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using UnityEngine;
+using WebSocketSharp;
+
+namespace SimpleChat
+{
+    // TODO: シングルトン化
+    public class HttpClient
+    {
+        private WebSocket ws;
+        public Action<string> ReceiveMessageCallback;
+
+        public HttpClient()
+        {
+            // TODO: プロトコルを wss にしたい see: https://github.com/sta/websocket-sharp
+            // TODO: 定数化。外だし
+            ws = new WebSocket("ws://localhost:3000/");
+            ws.OnOpen += OnOpen;
+            ws.OnMessage += OnMessage;
+            ws.OnError += OnError;
+            ws.OnClose += OnClose;
+        }
+
+        public void TryConnect()
+        {
+            ws.Connect();
+        }
+
+        public void OnOpen(object sender, System.EventArgs e)
+        {
+            Debug.Log("WebSocket Open");
+        }
+
+        public void OnMessage(object sender, MessageEventArgs e)
+        {
+            string message = System.Text.Encoding.UTF8.GetString(e.RawData);
+            ReceiveMessageCallback(message);
+        }
+
+        public void SetReceiveMessageCallback(Action<string> callback)
+        {
+            ReceiveMessageCallback = callback;
+        }
+
+        public void OnError(object sender, ErrorEventArgs e)
+        {
+            Debug.Log("WebSocket Error Message: " + e.Message);
+        }
+
+        public void OnClose(object sender, CloseEventArgs e)
+        {
+            Debug.Log("WebSocket Close");
+        }
+
+        public void Send(string message)
+        {
+            byte[] data = System.Text.Encoding.UTF8.GetBytes(message);
+            ws.Send(data);
+        }
+
+        public void Destroy()
+        {
+            ws.Close();
+            ws = null;
+        }
+    }
+}

--- a/simple-chat/Assets/Script/SimpleChat/HttpClient.cs.meta
+++ b/simple-chat/Assets/Script/SimpleChat/HttpClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ab9f1c41214544e9a53192f88e570f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/simple-chat/Assets/Script/SimpleChat/InputFieldView.cs
+++ b/simple-chat/Assets/Script/SimpleChat/InputFieldView.cs
@@ -4,6 +4,11 @@ using UnityEngine.UI;
 
 namespace SimpleChat
 {
+    /// <summary>
+    /// InputField に付与されるクラス。
+    /// 入力を受けて ScrollView にメッセージを出力する。
+    /// 外部からの入力も受け付けて ScrollView にメッセージとして表示できる。
+    /// </summary>
     public class InputFieldView : MonoBehaviour
     {
         [SerializeField]
@@ -13,11 +18,15 @@ namespace SimpleChat
         [SerializeField]
         private RectTransform chatLogContent;
 
+        // 位置を微調整するために必要
         private Vector3 initialLocalScale = new Vector3(1, 1, 1);
 
         private RectTransform clonedMessageRectTransform;
         private InputField inputField;
-        public InputField InputField { get { return inputField; }  }
+
+        public Action<string> InputMessageCallback = null;
+
+        #region LifeCycleMethods
 
         public void Awake()
         {
@@ -30,22 +39,44 @@ namespace SimpleChat
             inputField.onEndEdit.AddListener(delegate { OnEndEdit(inputField); });
         }
 
+        #endregion
+
+        /// <summary>
+        /// 入力が完了する(Enter)と、発火する
+        /// </summary>
+        /// <param name="input">Input.</param>
         private void OnEndEdit(InputField input)
         {
+            // 日本語に対応するには textComponent から参照しなければならない
+            string message = input.textComponent.text
+                                  ;
             // 全角だろうが空白のみは許容しない
-            if (input.textComponent.text.Trim().Equals(string.Empty)) {
+            if (message.Trim().Equals(string.Empty)) {
                 return;
             }
 
-            // 日本語に対応するには textComponent から参照しなければならない
-            AddMessageView(myMessageView, input.textComponent.text);
+            AddMessageView(myMessageView, message);
+            if (InputMessageCallback != null)
+            {
+                InputMessageCallback(message);
+            }
         }
 
+        /// <summary>
+        /// メッセージを SrollView に追加する。
+        /// 主に、外部からの入力を受け付けるために利用する。
+        /// </summary>
+        /// <param name="message">Message.</param>
         public void ReceiveMessage(string message)
         {
             AddMessageView(otherMessageView, message);
         }
 
+        /// <summary>
+        /// メッセージを ScrollView に追加する
+        /// </summary>
+        /// <param name="messageView">Message view.</param>
+        /// <param name="message">Message.</param>
         private void AddMessageView(RectTransform messageView, string message)
         {
             RectTransform clonedMessageView = Instantiate<RectTransform>(messageView);
@@ -57,16 +88,25 @@ namespace SimpleChat
             ResetInputField();
         }
 
+        /// <summary>
+        /// message として受け取った文字列を Text として gameObject にセットする
+        /// </summary>
+        /// <param name="clonedMessageView">Cloned message view.</param>
+        /// <param name="message">Message.</param>
         private void SetTextInContent(RectTransform clonedMessageView, string message)
         {
             // SerializeField を使ってキャッシュしたかったが、 clone しているので instanceId が異なるので使えない
             // 同様の理由で FindWithTag による参照もできないのでやむなし
             clonedMessageView.GetChild(1).GetComponent<Text>().text = message;
-            clonedMessageView.GetChild(2).GetComponent<Text>().text = CurrentDate();
+            clonedMessageView.GetChild(2).GetComponent<Text>().text = CurrentTime();
             clonedMessageView.SetParent(chatLogContent);
 
         }
 
+        /// <summary>
+        /// レイアウトを整える
+        /// </summary>
+        /// <param name="clonedMessageView">Cloned message view.</param>
         private void AdjustViewLayout(RectTransform clonedMessageView)
         {
             // SetParent 実行後、なぜか localScale が (0.5, 0.5, 0.5) に resize されてしまうので。
@@ -77,23 +117,38 @@ namespace SimpleChat
             clonedMessageView.GetComponent<RectTransform>().sizeDelta = new Vector2(w, h + padding);
         }
 
+        /// <summary>
+        /// 新しいメッセージの挿入位置を決める
+        /// </summary>
+        /// <param name="clonedMessageView">Cloned message view.</param>
         private void SetLayoutOrder(RectTransform clonedMessageView)
         {
             // 最新のコメントが一番上にくるように順序づけ
             clonedMessageView.SetAsFirstSibling();
         }
 
+        /// <summary>
+        /// gameObject が非表示なら可視化する
+        /// </summary>
+        /// <param name="clonedMessageView">Cloned message view.</param>
         private void BeVisibleView(RectTransform clonedMessageView)
         {
             clonedMessageView.gameObject.SetActive(true);
         }
 
+        /// <summary>
+        /// InputField を空の状態に戻す
+        /// </summary>
         private void ResetInputField()
         {
             inputField.text = string.Empty;
         }
 
-        private string CurrentDate()
+        /// <summary>
+        /// 現在時刻を[HH:mm]のフォーマットで返す 
+        /// </summary>
+        /// <returns>The date.</returns>
+        private string CurrentTime()
         {
             return DateTime.Now.ToString("HH:mm");
         }


### PR DESCRIPTION
https://github.com/shimomuh/simple-chat/issues/13 の対応。
一部リファクタを含む。
HttpClient クラスに分離することで、ミドルウェアは WebSocketSharp に拘らず、なんでもよくなるというメリットがある。