### PR TITLE
[QA] [Bugfix] スクロール可能なまで文字を打ち込んだ場合 iPhone X/XS 相当で表示が崩れる

### DIFF
--- a/client/unity/simple-chat/Assets/Prefab/SimpleChat.prefab
+++ b/client/unity/simple-chat/Assets/Prefab/SimpleChat.prefab
@@ -2090,10 +2090,10 @@ RectTransform:
   m_Father: {fileID: 224523350217607184}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 2204, y: 3610}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!224 &224951933215953266
 RectTransform:


### PR DESCRIPTION
https://github.com/shimomuh/simple-chat/issues/44 の対応
![2019-01-04 14 48 41](https://user-images.githubusercontent.com/10266013/50675238-1ba84d00-1030-11e9-99f1-0f3db0fa9964.png)
